### PR TITLE
Fix typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,8 +35,8 @@ func main() {
     // Out put is magenta
     println(gocolor.Purple("gocolor.Magenta()"))
 	
-    // Out put is cayn
-    println(gocolor.Cayn("gocolor.Cayn()"))
+    // Out put is Cyan
+    println(gocolor.Cyan("gocolor.Cyan()"))
 	
     // Out put is white
     println(gocolor.White("gocolor.White()"))

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ func main() {
     // Out put is magenta
     println(gocolor.Purple("gocolor.Magenta()"))
 	
-    // Out put is Cyan
+    // Out put is cyan
     println(gocolor.Cyan("gocolor.Cyan()"))
 	
     // Out put is white

--- a/main.go
+++ b/main.go
@@ -1,48 +1,48 @@
 package gocolor
 
-var defalt string = "\u001b[0m"
+var _default string = "\u001b[0m"
 
-func Defalt(text string) string {
+func Default(text string) string {
 	result := "\u001b[0m" + text
 	return result
 }
 
 func Red(text string) string {
-	result := "\u001b[31m" + text + defalt
+	result := "\u001b[31m" + text + _default
 	return result
 }
 
 func Blue(text string) string {
-	result := "\u001b[34m" + text + defalt
+	result := "\u001b[34m" + text + _default
 	return result
 }
 
 func Yellow(text string) string {
-	result := "\u001b[33m" + text + defalt
+	result := "\u001b[33m" + text + _default
 	return result
 }
 
 func Green(text string) string {
-	result := "\u001b[32m" + text + defalt
+	result := "\u001b[32m" + text + _default
 	return result
 }
 
 func Purple(text string) string {
-	result := "\u001b[35m" + text + defalt
+	result := "\u001b[35m" + text + _default
 	return result
 }
 
-func Cayn(text string) string {
-	result := "\u001b[36m" + text + defalt
+func Cyan(text string) string {
+	result := "\u001b[36m" + text + _default
 	return result
 }
 
 func White(text string) string {
-	result := "\u001b[37m" + text + defalt
+	result := "\u001b[37m" + text + _default
 	return result
 }
 
 func Black(text string) string {
-	result := "\u001b[30m" + text + defalt
+	result := "\u001b[30m" + text + _default
 	return result
 }

--- a/main.go
+++ b/main.go
@@ -3,46 +3,37 @@ package gocolor
 var _default string = "\u001b[0m"
 
 func Default(text string) string {
-	result := "\u001b[0m" + text
-	return result
+	return "\u001b[0m" + text
 }
 
 func Red(text string) string {
-	result := "\u001b[31m" + text + _default
-	return result
+	return "\u001b[31m" + text + _default
 }
 
 func Blue(text string) string {
-	result := "\u001b[34m" + text + _default
-	return result
+	return "\u001b[34m" + text + _default
 }
 
 func Yellow(text string) string {
-	result := "\u001b[33m" + text + _default
-	return result
+	return "\u001b[33m" + text + _default
 }
 
 func Green(text string) string {
-	result := "\u001b[32m" + text + _default
-	return result
+	return "\u001b[32m" + text + _default
 }
 
 func Purple(text string) string {
-	result := "\u001b[35m" + text + _default
-	return result
+	return "\u001b[35m" + text + _default
 }
 
 func Cyan(text string) string {
-	result := "\u001b[36m" + text + _default
-	return result
+	return "\u001b[36m" + text + _default
 }
 
 func White(text string) string {
-	result := "\u001b[37m" + text + _default
-	return result
+	return "\u001b[37m" + text + _default
 }
 
 func Black(text string) string {
-	result := "\u001b[30m" + text + _default
-	return result
+	return "\u001b[30m" + text + _default
 }

--- a/main.go
+++ b/main.go
@@ -1,39 +1,39 @@
 package gocolor
 
-var _default string = "\u001b[0m"
+var _default string = "\x1b[0m"
 
 func Default(text string) string {
-	return "\u001b[0m" + text
+	return "\x1b[0m" + text
 }
 
 func Red(text string) string {
-	return "\u001b[31m" + text + _default
+	return "\x1b[31m" + text + _default
 }
 
 func Blue(text string) string {
-	return "\u001b[34m" + text + _default
+	return "\x1b[34m" + text + _default
 }
 
 func Yellow(text string) string {
-	return "\u001b[33m" + text + _default
+	return "\x1b[33m" + text + _default
 }
 
 func Green(text string) string {
-	return "\u001b[32m" + text + _default
+	return "\x1b[32m" + text + _default
 }
 
 func Purple(text string) string {
-	return "\u001b[35m" + text + _default
+	return "\x1b[35m" + text + _default
 }
 
 func Cyan(text string) string {
-	return "\u001b[36m" + text + _default
+	return "\x1b[36m" + text + _default
 }
 
 func White(text string) string {
-	return "\u001b[37m" + text + _default
+	return "\x1b[37m" + text + _default
 }
 
 func Black(text string) string {
-	return "\u001b[30m" + text + _default
+	return "\x1b[30m" + text + _default
 }


### PR DESCRIPTION
このライブラリを使ってはないですが typo を見付けたので。
関数名が変わっているのでこのライブラリを使っている側の修正も必要です。